### PR TITLE
AGP 9.0.0 Migration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,8 @@
 import androidx.navigation.safeargs.gradle.ArgumentsGenerationTask
+import com.android.build.api.dsl.ApplicationExtension
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.devtools.ksp")
     id("androidx.navigation.safeargs.kotlin")
@@ -16,7 +16,7 @@ android {
     def date = new Date()
     def formattedDate = date.format('dd.MM.yyyy hh.mm a')
 
-    compileSdk rootProject.ext.compile_sdk_version
+    compileSdk = rootProject.ext.compile_sdk_version
 
     defaultConfig {
         applicationId "dev.atick.dispenser"
@@ -33,33 +33,33 @@ android {
 
     buildTypes {
         Properties properties = new Properties()
+
+        // FIXME: applicationVariants API is no longer available in AGP 9.0.0, need to find an alternative way
+        //  to rename the output APK file
         
         debug {
-            applicationVariants.all { variant ->
-                variant.outputs.all {
-                    outputFileName = "${"app_" + variant.buildType.name + "_v" + variant.versionName + "_" + formattedDate}.apk"
-                }
-            }
+//            applicationVariants.all { variant ->
+//                variant.outputs.all {
+//                    outputFileName = "${"app_" + variant.buildType.name + "_v" + variant.versionName + "_" + formattedDate}.apk"
+//                }
+//            }
             buildConfigField "String", "BROKER_URL", properties.getProperty("BROKER_URL", "\"\"")
         }
 
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            applicationVariants.all { variant ->
-                variant.outputs.all {
-                    outputFileName = "${"app_" + variant.buildType.name + "_v" + variant.versionName + "_" + formattedDate}.apk"
-                }
-            }
+//            applicationVariants.all { variant ->
+//                variant.outputs.all {
+//                    outputFileName = "${"app_" + variant.buildType.name + "_v" + variant.versionName + "_" + formattedDate}.apk"
+//                }
+//            }
             buildConfigField "String", "BROKER_URL", properties.getProperty("BROKER_URL", "\"\"")
         }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '17'
     }
     buildFeatures {
         compose true
@@ -88,7 +88,7 @@ dependencies {
     implementation("com.github.PhilJay:MPAndroidChart:3.1.0")
 
     // ... Google Analytics
-    implementation platform("com.google.firebase:firebase-bom:34.6.0")
+    implementation platform("com.google.firebase:firebase-bom:34.11.0")
     implementation("com.google.firebase:firebase-crashlytics")
     implementation("com.google.firebase:firebase-analytics")
 

--- a/bluetooth/build.gradle
+++ b/bluetooth/build.gradle
@@ -1,12 +1,11 @@
 plugins {
     id("com.android.library")
-    id("kotlin-android")
     id("com.google.devtools.ksp")
     id("dagger.hilt.android.plugin")
 }
 
 android {
-    compileSdk rootProject.ext.compile_sdk_version
+    compileSdk = rootProject.ext.compile_sdk_version
 
     defaultConfig {
         minSdk rootProject.ext.min_sdk_version
@@ -25,9 +24,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '17'
     }
     namespace "dev.atick.bluetooth"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,17 +6,17 @@ buildscript {
         version_code = 7
         version_name = "2.1.1"
 
-        agp_version = "8.13.1"
-        kotlin_version = "2.2.21"
+        agp_version = "9.1.0"
+        kotlin_version = "2.3.20"
 
         compose_bom_version = "2025.12.00"
         lifecycle_version = "2.10.0"
-        nav_version = "2.9.6"
+        nav_version = "2.9.7"
         room_version = "2.8.4"
-        hilt_version = "2.57.2"
+        hilt_version = "2.59.2"
         google_services_version = "4.4.4"
         crashlytics_version = "3.0.6"
-        ksp_version = "2.3.3"
+        ksp_version = "2.3.6"
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.library")
-    id("kotlin-android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.devtools.ksp")
     id("kotlinx-serialization")
@@ -9,7 +8,7 @@ plugins {
 }
 
 android {
-    compileSdk rootProject.ext.compile_sdk_version
+    compileSdk = rootProject.ext.compile_sdk_version
 
     defaultConfig {
         minSdk rootProject.ext.min_sdk_version
@@ -29,9 +28,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
     buildFeatures {
         compose true
         buildConfig true
@@ -47,7 +43,7 @@ android {
 dependencies {
 
     // ... Core
-    api("androidx.core:core-ktx:1.17.0")
+    api("androidx.core:core-ktx:1.18.0")
     api("androidx.appcompat:appcompat:1.7.1")
     api("com.google.android.material:material:1.13.0")
 
@@ -63,7 +59,7 @@ dependencies {
     api("androidx.compose.material:material-icons-core")
     api("androidx.compose.material:material-icons-extended")
     api("androidx.compose.runtime:runtime-livedata")
-    api("androidx.activity:activity-compose:1.12.1")
+    api("androidx.activity:activity-compose:1.13.0")
 
     // ... Lifecycle
     api("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version")
@@ -80,7 +76,7 @@ dependencies {
     api("androidx.navigation:navigation-ui-ktx:$nav_version")
 
     // ... Serialization
-    api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+    api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
 
     // ... Dagger Hilt
     api("com.google.dagger:hilt-android:$hilt_version")

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -2,5 +2,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,13 +1,12 @@
 plugins {
     id("com.android.library")
-    id("kotlin-android")
     id("com.google.devtools.ksp")
     id("kotlinx-serialization")
     id("dagger.hilt.android.plugin")
 }
 
 android {
-    compileSdk rootProject.ext.compile_sdk_version
+    compileSdk = rootProject.ext.compile_sdk_version
 
     defaultConfig {
         minSdk rootProject.ext.min_sdk_version
@@ -27,9 +26,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = '17'
-    }
     namespace "dev.atick.data"
 }
 
@@ -42,7 +38,7 @@ dependencies {
     ksp("androidx.room:room-compiler:$room_version")
 
     // ... Datastore
-    implementation("androidx.datastore:datastore-preferences:1.2.0")
+    implementation("androidx.datastore:datastore-preferences:1.2.1")
 
     // ... Dagger Hilt
     api("com.google.dagger:hilt-android:$hilt_version")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,8 @@
+#Tue Mar 31 19:50:38 AST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/mqtt/build.gradle
+++ b/mqtt/build.gradle
@@ -1,12 +1,11 @@
 plugins {
     id("com.android.library")
-    id("kotlin-android")
     id("com.google.devtools.ksp")
     id("dagger.hilt.android.plugin")
 }
 
 android {
-    compileSdk rootProject.ext.compile_sdk_version
+    compileSdk = rootProject.ext.compile_sdk_version
 
     defaultConfig {
         minSdk rootProject.ext.min_sdk_version
@@ -26,9 +25,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = '17'
-    }
     packagingOptions {
         resources {
             excludes += ['META-INF/INDEX.LIST', 'META-INF/io.netty.versions.properties']
@@ -42,7 +38,7 @@ dependencies {
     implementation(project(":data"))
 
     // ... HiveMq
-    api("com.hivemq:hivemq-mqtt-client:1.3.10")
+    api("com.hivemq:hivemq-mqtt-client:1.3.13")
 
     // ... Dagger Hilt
     api("com.google.dagger:hilt-android:$hilt_version")

--- a/network/build.gradle
+++ b/network/build.gradle
@@ -1,12 +1,11 @@
 plugins {
     id("com.android.library")
-    id("kotlin-android")
     id("com.google.devtools.ksp")
     id("dagger.hilt.android.plugin")
 }
 
 android {
-    compileSdk rootProject.ext.compile_sdk_version
+    compileSdk = rootProject.ext.compile_sdk_version
 
     defaultConfig {
         minSdk rootProject.ext.min_sdk_version
@@ -25,9 +24,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '17'
     }
     buildFeatures {
         buildConfig true


### PR DESCRIPTION
This pull request updates the build configuration and dependencies across multiple modules to support newer versions of Gradle and Android Gradle Plugin (AGP), while also upgrading several library dependencies. It removes deprecated or redundant plugin usages and configuration blocks, and addresses compatibility issues introduced by AGP 9.0.0. The most important changes are grouped below.

**Build System and Plugin Configuration Updates:**
- Upgraded Gradle to version 9.3.1 and added a SHA256 checksum for improved security in `gradle-wrapper.properties`.
- Updated all `build.gradle` files to use the `compileSdk = ...` assignment syntax, as required by newer AGP versions, and removed the `kotlin-android` plugin from all modules. [[1]](diffhunk://#diff-51a0b488f963eb0be6c6599bf5df497313877cf5bdff3950807373912ac1cdc9R2-L5) [[2]](diffhunk://#diff-9cde553068059e70d8dea856dea6934526cdf5ac264fef12ccbf92a94d369402L3-R8) [[3]](diffhunk://#diff-8661f4ba56dd608a0331a1b951fcc910c80ddd53de7dec30cdf6c0e773cab6d0L3) [[4]](diffhunk://#diff-84b3883fa5c94dc767a7347b8fed331e865d9a996b1e141085b70f8f180d8fa7L3-R9) [[5]](diffhunk://#diff-93a02eeac6d47bd4948baa2e8f7c3eaf46c19a18360245f36870afc2cedf0d50L3-R8) [[6]](diffhunk://#diff-b7fbe2e15184b5a1328ed60a9ac5f8292302fab0bfb383bc05ee44ffeafe90c2L3-R8)
- Removed `kotlinOptions` blocks specifying `jvmTarget` from all modules, as this is now handled elsewhere or is redundant with the current toolchain. [[1]](diffhunk://#diff-51a0b488f963eb0be6c6599bf5df497313877cf5bdff3950807373912ac1cdc9R37-L63) [[2]](diffhunk://#diff-9cde553068059e70d8dea856dea6934526cdf5ac264fef12ccbf92a94d369402L29-L31) [[3]](diffhunk://#diff-8661f4ba56dd608a0331a1b951fcc910c80ddd53de7dec30cdf6c0e773cab6d0L32-L34) [[4]](diffhunk://#diff-84b3883fa5c94dc767a7347b8fed331e865d9a996b1e141085b70f8f180d8fa7L30-L32) [[5]](diffhunk://#diff-93a02eeac6d47bd4948baa2e8f7c3eaf46c19a18360245f36870afc2cedf0d50L29-L31) [[6]](diffhunk://#diff-b7fbe2e15184b5a1328ed60a9ac5f8292302fab0bfb383bc05ee44ffeafe90c2L29-L31)

**Dependency Upgrades:**
- Upgraded Firebase BOM to 34.11.0 in `app/build.gradle`.
- Updated several core libraries in `core/build.gradle`, including `androidx.core:core-ktx` to 1.18.0, `androidx.activity:activity-compose` to 1.13.0, and `kotlinx-serialization-json` to 1.10.0. [[1]](diffhunk://#diff-8661f4ba56dd608a0331a1b951fcc910c80ddd53de7dec30cdf6c0e773cab6d0L50-R46) [[2]](diffhunk://#diff-8661f4ba56dd608a0331a1b951fcc910c80ddd53de7dec30cdf6c0e773cab6d0L66-R62) [[3]](diffhunk://#diff-8661f4ba56dd608a0331a1b951fcc910c80ddd53de7dec30cdf6c0e773cab6d0L83-R79)
- Upgraded `androidx.datastore:datastore-preferences` to 1.2.1 in `data/build.gradle`.
- Updated `com.hivemq:hivemq-mqtt-client` to 1.3.13 in `mqtt/build.gradle`.

**Android Gradle Plugin (AGP) Compatibility Adjustments:**
- Commented out the use of the `applicationVariants` API for APK renaming in `app/build.gradle` due to its removal in AGP 9.0.0, and added a `FIXME` note to find an alternative approach.

**Other Minor Fixes:**
- Removed a duplicate `ACCESS_NETWORK_STATE` permission from `core/src/main/AndroidManifest.xml`.